### PR TITLE
Remove mismatched license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
-
-
 # SEODeploy: Flexible and Modular Python Library for Automating SEO Testing in Deployment Pipelines.
 
 ![SEOTesting](/docs/images/overview.png "SEO Testing Overview")


### PR DESCRIPTION
The source code shows MIT license while the README lists it as Apache 2.0. 
These are not the same, and the source code takes precedence over a badge.